### PR TITLE
Terraform import DNS Mappings for Blog-Server infrastructure

### DIFF
--- a/terraform/environments/production.tfvars
+++ b/terraform/environments/production.tfvars
@@ -6,3 +6,4 @@ cloud_run_min_replica   = 0
 cloud_run_max_replica   = 1
 db_user                 = "amplication"
 db_name                 = "blog"
+host                    = "blog-api.amplication.com"

--- a/terraform/environments/staging.tfvars
+++ b/terraform/environments/staging.tfvars
@@ -6,3 +6,4 @@ cloud_run_min_replica   = 0
 cloud_run_max_replica   = 1
 db_user                 = "amplication"
 db_name                 = "blog"
+host                    = "staging-blog-api.amplication.com"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -81,3 +81,16 @@ resource "google_cloud_run_service_iam_member" "run_all_users" {
   role     = "roles/run.invoker"
   member   = "allUsers"
 }
+
+resource "google_cloud_run_domain_mapping" "mapping" {
+  location = var.region
+  name     = var.host
+
+  metadata {
+    namespace = var.project_id
+  }
+
+  spec {
+    route_name = google_cloud_run_service.service.name
+  }
+}

--- a/terraform/readme.md
+++ b/terraform/readme.md
@@ -46,3 +46,20 @@ export TF_VAR_image=gcr.io/amplication/blog-server:v1.0.0-example
 terraform init -backend-config="prefix=amplication-blog-server/production"
 terraform apply --var-file=environments/production.tfvars
 ```
+
+### Terraform Import
+The DNS Mappings for the Cloud Run service for both `staging` and `production` need to be imported. If changes are required for Cloud Run DNS you'll need to re-import. Follow below steps...
+
+Domain Mapping can be imported using this accepted format:
+
+```
+$ terraform import google_cloud_run_domain_mapping.default locations/{{location}}/namespaces/{{project}}/domainmappings/{{name}}
+```
+
+The current Terraform state is imported like so...
+```sh
+# Staging
+terraform import --var-file=environments/staging.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/staging-blog-api.amplication.com
+
+# Production
+terraform import --var-file=environments/production.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/blog-api.amplication.com

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,3 +38,7 @@ variable "db_password" {
   type  = string
   sensitive = true
 }
+
+variable "host" {
+  type  = string
+}


### PR DESCRIPTION
Issues: https://github.com/amplication/blog-server/issues/3

The DNS Mappings for the Cloud Run service for both `staging` and `production` need to be imported. If changes are required for Cloud Run DNS you'll need to re-import. Follow below steps...

Domain Mapping can be imported using this accepted format:

```
$ terraform import google_cloud_run_domain_mapping.default locations/{{location}}/namespaces/{{project}}/domainmappings/{{name}}
```

The current Terraform state is imported like so...
```sh
# Staging
terraform import --var-file=environments/staging.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/staging-blog-api.amplication.com

# Production
terraform import --var-file=environments/production.tfvars google_cloud_run_domain_mapping.mapping locations/us-east1/namespaces/amplication/domainmappings/blog-api.amplication.com